### PR TITLE
Update package.json with correct license

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/codetunnel/angular-spinners.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/codetunnel/angular-spinners/issues"
   },


### PR DESCRIPTION
I supposed license is MIT as described in bower.json and README
